### PR TITLE
Fix __getitem__ stop index

### DIFF
--- a/adafruit_24lc32.py
+++ b/adafruit_24lc32.py
@@ -116,7 +116,7 @@ class EEPROM:
             regs = list(
                 range(
                     address.start if address.start is not None else 0,
-                    address.stop + 1 if address.stop is not None else self._max_size,
+                    address.stop if address.stop is not None else self._max_size,
                 )
             )
             if regs[0] < 0 or (regs[0] + len(regs)) > self._max_size:


### PR DESCRIPTION
Fixes the `__getitem__` return a slice 1 item too long.  I'll also make the same fix for the FRAM library.