### PR TITLE
Update adafruit_24lc32.py to add max_size parameter to EEPROM_I2C

### DIFF
--- a/adafruit_24lc32.py
+++ b/adafruit_24lc32.py
@@ -234,7 +234,7 @@ class EEPROM_I2C(EEPROM):
         address: int = 0x50,
         write_protect: bool = False,
         wp_pin: Optional[DigitalInOut] = None,
-        max_size: int = _MAX_SIZE_I2C
+        max_size: int = _MAX_SIZE_I2C,
     ) -> None:
         from adafruit_bus_device.i2c_device import (  # pylint: disable=import-outside-toplevel
             I2CDevice as i2cdev,

--- a/adafruit_24lc32.py
+++ b/adafruit_24lc32.py
@@ -223,6 +223,8 @@ class EEPROM_I2C(EEPROM):
         Default is ``False``.
     :param wp_pin: (Optional) Physical pin connected to the ``WP`` breakout pin.
         Must be a ``DigitalInOut`` object.
+    :param max_int: (Optional) Maximum # bytes stored in the EEPROM.
+        Default is ``_MAX_SIZE_I2C``
     """
 
     # pylint: disable=too-many-arguments
@@ -232,7 +234,7 @@ class EEPROM_I2C(EEPROM):
         address: int = 0x50,
         write_protect: bool = False,
         wp_pin: Optional[DigitalInOut] = None,
-        max_size: in = _MAX_SIZE_I2C
+        max_size: int = _MAX_SIZE_I2C
     ) -> None:
         from adafruit_bus_device.i2c_device import (  # pylint: disable=import-outside-toplevel
             I2CDevice as i2cdev,

--- a/adafruit_24lc32.py
+++ b/adafruit_24lc32.py
@@ -232,13 +232,14 @@ class EEPROM_I2C(EEPROM):
         address: int = 0x50,
         write_protect: bool = False,
         wp_pin: Optional[DigitalInOut] = None,
+        max_size: in = _MAX_SIZE_I2C
     ) -> None:
         from adafruit_bus_device.i2c_device import (  # pylint: disable=import-outside-toplevel
             I2CDevice as i2cdev,
         )
 
         self._i2c = i2cdev(i2c_bus, address)
-        super().__init__(_MAX_SIZE_I2C, write_protect, wp_pin)
+        super().__init__(max_size, write_protect, wp_pin)
 
     def _read_address(self, address: int, read_buffer: bytearray) -> bytearray:
         write_buffer = bytearray(2)


### PR DESCRIPTION
I would like to use this library with other EEPROMs in the 24C series or other EEPROMs that use the same I2C protocol. The only real difference is that they have different maximum sizes. The minimal change is to add a parameter to specify that maximum size.

This also resolves issue #3.