### PR TITLE
Minor correction to the Read The Docs

### DIFF
--- a/adafruit_24lc32.py
+++ b/adafruit_24lc32.py
@@ -223,7 +223,7 @@ class EEPROM_I2C(EEPROM):
         Default is ``False``.
     :param wp_pin: (Optional) Physical pin connected to the ``WP`` breakout pin.
         Must be a ``DigitalInOut`` object.
-    :param max_int: (Optional) Maximum # bytes stored in the EEPROM.
+    :param int max_size: (Optional) Maximum # bytes stored in the EEPROM.
         Default is ``_MAX_SIZE_I2C``
     """
 


### PR DESCRIPTION
Under the I2C class for EEPROM parameters currently reads as "max_int – (Optional) " should be "max_size (int) - (Optional)"

Also I didn't know how to do it, but in the read the docs page the " Default is ``_MAX_SIZE_I2C`` " part reads out at literally "_MAX_SIZE_I2C" instead of like it does above in the class

class adafruit_24lc32.EEPROM_I2C(i2c_bus: busio.I2C, address: int = 80, write_protect: bool = False, wp_pin: DigitalInOut | None = None, max_size: int = 4096)¶