### PR TITLE
only write if values differ

### DIFF
--- a/adafruit_24lc32.py
+++ b/adafruit_24lc32.py
@@ -177,8 +177,8 @@ class EEPROM:
                         address, self._max_size
                     )
                 )
-
-            self._write(address, value, self._wraparound)
+            if self[address] != bytearray([value]):
+                self._write(address, value, self._wraparound)
 
         elif isinstance(address, slice):
             if not isinstance(value, (bytes, bytearray, list, tuple)):
@@ -200,8 +200,8 @@ class EEPROM:
                 raise ValueError(
                     "Cannot set values with a list smaller than the number of indexes"
                 )
-
-            self._write(address.start, value, self._wraparound)
+            if self[address] != bytes(value):
+                self._write(address.start, value, self._wraparound)
 
     def _read_address(self, address: int, read_buffer: bytearray) -> bytearray:
         # Implemented by subclass


### PR DESCRIPTION
@ladyada
Resolves: #9 

Confirmed on hardware writing 4 bytes takes around `0.1`, with this change when we attempt to write the same 4 bytes it takes more like `0.005` due to skipping the write.